### PR TITLE
Access strong reference of self's layer to prevent dereference

### DIFF
--- a/Bartinter/Source/Bartinter.swift
+++ b/Bartinter/Source/Bartinter.swift
@@ -61,10 +61,11 @@ public final class Bartinter: UIViewController {
         guard let layer = parent?.view.layer else { return }
         let scale: CGFloat = 0.5
         let size = UIApplication.shared.statusBarFrame.size
-        throttler.throttle {
+        throttler.throttle { [weak self] in
+            guard let strongLayer = self?.parent?.view.layer else { return }
             UIGraphicsBeginImageContextWithOptions(size, false, scale)
             guard let context = UIGraphicsGetCurrentContext() else { return }
-            layer.render(in: context)
+            strongLayer.render(in: context)
             let image = UIGraphicsGetImageFromCurrentImageContext()
             guard let averageLuminance = image?.averageLuminance else { return }
             UIGraphicsEndImageContext()


### PR DESCRIPTION
I would like to propose this change in the throttle asynchronous call, to access a strong reference to Bartinter's layer, to avoid attempt to dereference garbage pointer.

I received this as a crash report in my app which uses Bartinter, which crashes in the first closure of Throttler.throttle, I believe that the reference to layer outside the closure can become lost.